### PR TITLE
Update render_change_form for Django 1.0+

### DIFF
--- a/eav/admin.py
+++ b/eav/admin.py
@@ -29,8 +29,8 @@ from .models import Attribute, Value, EnumValue, EnumGroup
 
 
 class BaseEntityAdmin(ModelAdmin):
-
-    def render_change_form(self, request, context, **kwargs):
+    
+    def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
         """
         Wrapper for ModelAdmin.render_change_form. Replaces standard static
         AdminForm with an EAV-friendly one. The point is that our form generates
@@ -50,7 +50,7 @@ class BaseEntityAdmin(ModelAdmin):
         context.update(adminform=adminform, media=media)
 
         super_meth = super(BaseEntityAdmin, self).render_change_form
-        return super_meth(request, context, **kwargs)
+        return super_meth(request, context, add, change, form_url, obj)
 
 
 class BaseEntityInlineFormSet(BaseInlineFormSet):


### PR DESCRIPTION
Django 1.0+ take more arguments than 0.96. I've updated admin.py to handle these new args properly.
