### PR TITLE
Some Admin fixes

### DIFF
--- a/eav/admin.py
+++ b/eav/admin.py
@@ -27,7 +27,6 @@ from django.utils.safestring import mark_safe
 
 from .models import Attribute, Value, EnumValue, EnumGroup
 
-
 class BaseEntityAdmin(ModelAdmin):
     
     def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
@@ -95,7 +94,8 @@ class BaseEntityInline(InlineModelAdmin):
         return [(None, {'fields': form.fields.keys()})]
 
 class AttributeAdmin(ModelAdmin):
-    list_display = ('name', 'slug', 'datatype', 'description')
+    list_display = ('name', 'slug', 'datatype', 'description', 'site')
+    list_filter = ['site']
     prepopulated_fields = {'slug': ('name',)}
 
 admin.site.register(Attribute, AttributeAdmin)

--- a/eav/models.py
+++ b/eav/models.py
@@ -204,8 +204,8 @@ class Attribute(models.Model):
 
     required = models.BooleanField(_(u"required"), default=False)
 
-    on_site = CurrentSiteManager()
     objects = models.Manager()
+    on_site = CurrentSiteManager()
 
     def get_validators(self):
         '''


### PR DESCRIPTION
To better support site-based attributes, I updated the admin for Attribute by adding 'site' to list_filter and list_display. I also reversed the order of the objects and on_site properties of Attribute so that the default listing in the admin would list _all_ attributes, not just those from the default site.
