### PR TITLE
Two small modifications

### DIFF
--- a/eav/fields.py
+++ b/eav/fields.py
@@ -85,6 +85,6 @@ class EavDatatypeField(models.CharField):
         from .models import Attribute
         if not instance.pk:
             return
-        if value != instance.value and instance.value_set.count():
+        if value != instance.datatype and instance.value_set.count():
             raise ValidationError(_(u"You cannot change the datatype of an "
                                     u"attribute that is already in use."))

--- a/eav/fields.py
+++ b/eav/fields.py
@@ -85,6 +85,6 @@ class EavDatatypeField(models.CharField):
         from .models import Attribute
         if not instance.pk:
             return
-        if value != self.value and instance.value_set.count():
+        if value != instance.value and instance.value_set.count():
             raise ValidationError(_(u"You cannot change the datatype of an "
                                     u"attribute that is already in use."))

--- a/eav/fields.py
+++ b/eav/fields.py
@@ -85,6 +85,6 @@ class EavDatatypeField(models.CharField):
         from .models import Attribute
         if not instance.pk:
             return
-        if value != instance.datatype and instance.value_set.count():
+        if value != getattr(instance, self.name) and instance.value_set.count():
             raise ValidationError(_(u"You cannot change the datatype of an "
                                     u"attribute that is already in use."))

--- a/eav/fields.py
+++ b/eav/fields.py
@@ -85,6 +85,6 @@ class EavDatatypeField(models.CharField):
         from .models import Attribute
         if not instance.pk:
             return
-        if instance.value_set.count():
+        if value != self.value and instance.value_set.count():
             raise ValidationError(_(u"You cannot change the datatype of an "
                                     u"attribute that is already in use."))

--- a/eav/managers.py
+++ b/eav/managers.py
@@ -102,9 +102,15 @@ def expand_eav_filter(model_cls, key, value):
         gr_name = config_cls.generic_relation_attr
         datatype = Attribute.objects.get(slug=slug).datatype
 
-        lookup = '__%s' % fields[2] if len(fields) > 2 else ''
-        kwargs = {'value_%s%s' % (datatype, lookup): value,
-                  'attribute__slug': slug}
+        if datatype == Attribute.TYPE_OBJECT:
+            query_key = 'generic_value_id'
+        else:
+            lookup = '__%s' % fields[2] if len(fields) > 2 else ''
+            query_key = 'value_%s%s' % (datatype, lookup)
+        kwargs = {
+            query_key: value,
+            'attribute__slug': slug
+        }
         value = Value.objects.filter(**kwargs)
 
         return '%s__in' % gr_name, value

--- a/eav/models.py
+++ b/eav/models.py
@@ -521,11 +521,14 @@ class Entity(object):
         '''
         return self.get_all_attributes().get(slug=slug)
 
-    def get_value_by_attribute(self, attribute):
+    def get_value_by_attribute(self, attribute, default=None):
         '''
         Returns a single :class:`Value` for *attribute*
         '''
-        return self.get_values().get(attribute=attribute)
+        try:
+            return self.get_values().get(attribute=attribute)
+        except Value.DoesNotExist:
+            return default
 
     def __iter__(self):
         '''

--- a/eav/models.py
+++ b/eav/models.py
@@ -152,7 +152,7 @@ class Attribute(models.Model):
 
     class Meta:
         ordering = ['order', 'name']
-        unique_together = ('site', 'slug')
+        unique_together = ('site', 'slug', 'type')
 
     TYPE_TEXT = 'text'
     TYPE_FLOAT = 'float'

--- a/eav/models.py
+++ b/eav/models.py
@@ -151,7 +151,7 @@ class Attribute(models.Model):
     '''
 
     class Meta:
-        ordering = ['name']
+        ordering = ['order', 'name']
         unique_together = ('site', 'slug')
 
     TYPE_TEXT = 'text'
@@ -314,10 +314,6 @@ class Attribute(models.Model):
 
     def __unicode__(self):
         return u"%s (%s)" % (self.name, self.get_datatype_display())
-
-    class Meta:
-        ordering = ['order', 'name']
-
 
 
 class Value(models.Model):

--- a/eav/models.py
+++ b/eav/models.py
@@ -77,7 +77,7 @@ class EnumValue(models.Model):
        for both *EnumGroups*.
     '''
     value = models.CharField(_(u"value"), db_index=True,
-                             unique=True, max_length=50)
+                             unique=True, max_length=100)
 
     def __unicode__(self):
         return self.value

--- a/eav/models.py
+++ b/eav/models.py
@@ -397,6 +397,13 @@ class Value(models.Model):
         return u"%s - %s: \"%s\"" % (self.entity, self.attribute.name,
                                      self.value)
 
+    def get_actual_value(self):
+        '''
+        Returns the value actually in the database, for use in forms.
+        '''
+        return getattr(self.value, "pk",
+                       getattr(self.value, "value", self.value))
+
 
 class Entity(object):
     '''

--- a/eav/models.py
+++ b/eav/models.py
@@ -261,7 +261,7 @@ class Attribute(models.Model):
         '''
         if self.datatype == self.TYPE_ENUM and not self.enum_group:
             raise ValidationError(_(
-                u"You must set the choice group for multiple choice" \
+                u"You must set the choice group for multiple choice " \
                 u"attributes"))
 
         if self.datatype != self.TYPE_ENUM and self.enum_group:

--- a/eav/models.py
+++ b/eav/models.py
@@ -204,6 +204,8 @@ class Attribute(models.Model):
 
     required = models.BooleanField(_(u"required"), default=False)
 
+    order = models.FloatField(_(u"order"), default=0.0, blank=True)
+
     objects = models.Manager()
     on_site = CurrentSiteManager()
 
@@ -312,6 +314,10 @@ class Attribute(models.Model):
 
     def __unicode__(self):
         return u"%s (%s)" % (self.name, self.get_datatype_display())
+
+    class Meta:
+        ordering = ['order', 'name']
+
 
 
 class Value(models.Model):

--- a/eav/models.py
+++ b/eav/models.py
@@ -582,16 +582,3 @@ if 'django_nose' in settings.INSTALLED_APPS:
     Please, someone tell me a better way to do this.
     '''
     from .tests.models import Patient, Encounter
-
-
-
-
-def eav_get_values_dict(entity):
-    dict = {}
-    for attr in entity.get_all_attributes():
-        value = entity.get_value_by_attribute(attr)
-        if value is not None:
-            value = value.get_actual_value()
-        dict[attr.slug] = value
-    return dict
-Entity.get_values_dict = eav_get_values_dict


### PR DESCRIPTION
I've done two changes which I think are generally useful:
1. Added the method `Value.get_actual_value`: it returns the actual value stored in the database, which is useful when populating a form.
2. Modified the method `Entity.get_value_by_attribute` by adding default value, which is `None` by default. I don't see a point in throwing an exception when an attribute is not set; a more often use case is that one will iterate through the attributes to get their values, and default comes handy in those cases.
