### PR TITLE
Create timezone aware timestamps

### DIFF
--- a/eav/models.py
+++ b/eav/models.py
@@ -33,7 +33,7 @@ Classes
 -------
 '''
 
-from datetime import datetime
+import django.utils.timezone as datetime
 
 from django.db import models
 from django.core.exceptions import ValidationError


### PR DESCRIPTION
See also: https://docs.djangoproject.com/en/dev/topics/i18n/timezones/

This suppresses warnings like this when creating an object with EAVs:
RuntimeWarning: DateTimeField received a naive datetime (2013-03-11 13:55:20.548024) while time zone support is active.
