### PR TITLE
Change get_or_create() to return tuple

### DIFF
--- a/eav/managers.py
+++ b/eav/managers.py
@@ -184,6 +184,6 @@ class EntityManager(models.Manager):
         Reproduces the behavior of get_or_create, eav friendly.
         '''
         try:
-            return self.get(**kwargs)
+            return self.get(**kwargs), False
         except self.model.DoesNotExist:
-            return self.create(**kwargs)
+            return self.create(**kwargs), True


### PR DESCRIPTION
Change get_or_create() to return a tuple, confirming to Django's default behaviour ( see https://docs.djangoproject.com/en/dev/ref/models/querysets/#get-or-create )
