### PR TITLE
bugfix #26 - support for new ContentType-s field related_query_name

### DIFF
--- a/eav/registry.py
+++ b/eav/registry.py
@@ -166,7 +166,7 @@ class Registry(object):
                      generic.GenericRelation(Value,
                                              object_id_field='entity_id',
                                              content_type_field='entity_ct',
-                                             related_name=rel_name)
+                                             related_query_name=rel_name)
         generic_relation.contribute_to_class(self.model_cls, gr_name)
 
     def _detach_generic_relation(self):


### PR DESCRIPTION
GenericRelation's field related_name changed to related_query_name in Django 1.7
