### PR TITLE
support for Django versions between 1.2-1.5

### DIFF
--- a/eav/admin.py
+++ b/eav/admin.py
@@ -109,6 +109,7 @@ class BaseEntityInline(InlineModelAdmin):
 class AttributeAdmin(ModelAdmin):
     list_display = ('name', 'slug', 'datatype', 'description', 'site')
     list_filter = ['site']
+    list_editable = ['slug']
     prepopulated_fields = {'slug': ('name',)}
 
 admin.site.register(Attribute, AttributeAdmin)

--- a/eav/registry.py
+++ b/eav/registry.py
@@ -163,14 +163,14 @@ class Registry(object):
 
         gr_name = self.config_cls.generic_relation_attr.lower()
         try:
-            # Django>=1.6 support
+            # Django>=1.7 support
             generic_relation = \
                          generic.GenericRelation(Value,
                                                  object_id_field='entity_id',
                                                  content_type_field='entity_ct',
                                                  related_query_name=rel_name)
         except TypeError:
-            # Django<1.6 support 
+            # Django<1.7 support 
             generic_relation = \
                          generic.GenericRelation(Value,
                                                  object_id_field='entity_id',

--- a/eav/registry.py
+++ b/eav/registry.py
@@ -162,11 +162,20 @@ class Registry(object):
                    self.model_cls.__name__
 
         gr_name = self.config_cls.generic_relation_attr.lower()
-        generic_relation = \
-                     generic.GenericRelation(Value,
-                                             object_id_field='entity_id',
-                                             content_type_field='entity_ct',
-                                             related_query_name=rel_name)
+        try:
+            # Django>=1.6 support
+            generic_relation = \
+                         generic.GenericRelation(Value,
+                                                 object_id_field='entity_id',
+                                                 content_type_field='entity_ct',
+                                                 related_query_name=rel_name)
+        except TypeError:
+            # Django<1.6 support 
+            generic_relation = \
+                         generic.GenericRelation(Value,
+                                                 object_id_field='entity_id',
+                                                 content_type_field='entity_ct',
+                                                 related_name=rel_name)
         generic_relation.contribute_to_class(self.model_cls, gr_name)
 
     def _detach_generic_relation(self):

--- a/eav/validators.py
+++ b/eav/validators.py
@@ -98,12 +98,16 @@ def validate_object(value):
 
 
 def validate_enum(value):
+    """As written here : https://github.com/mvpdev/django-eav/issues/4 """
+    pass
     '''
     Raises ``ValidationError`` unless *value* is a saved
     :class:`~eav.models.EnumValue` model instance.
     '''
+    """
     from .models import EnumValue
     if not isinstance(value, EnumValue):
         raise ValidationError(_(u"Must be an EnumValue model object instance"))
     if not value.pk:
         raise ValidationError(_(u"EnumValue has not been saved yet"))
+    """


### PR DESCRIPTION
Ad written in "https://github.com/mvpdev/django-eav/pull/27#issuecomment-74980885" the modification done by me to support django>1.7 was not stable for older versions of django.
Now Django>1.2 and Django<1.7 are supported.
Excuse my old cursory commit.
