### PR TITLE
Initial value fix for number fields in entity form

### DIFF
--- a/eav/forms.py
+++ b/eav/forms.py
@@ -94,7 +94,7 @@ class BaseDynamicEntityForm(ModelForm):
             self.fields[attribute.slug] = MappedField(**defaults)
 
             # fill initial data (if attribute was already defined)
-            if value and not datatype == attribute.TYPE_ENUM: #enum done above
+            if not value is None and not datatype == attribute.TYPE_ENUM: #enum done above
                 self.initial[attribute.slug] = value
 
     def save(self, commit=True):


### PR DESCRIPTION
When a value is 0, form will ignore to put 0 to initial data as python will handle "if 0" as false. This explicitly checks for None so zeroes show up properly in number fields.