### PR TITLE
updated depracated references of NullBooleanField for Django 4.0

### DIFF
--- a/eav/migrations/0001_initial.py
+++ b/eav/migrations/0001_initial.py
@@ -64,7 +64,7 @@ class Migration(migrations.Migration):
                 ('value_float', models.FloatField(blank=True, null=True)),
                 ('value_int', models.IntegerField(blank=True, null=True)),
                 ('value_date', models.DateTimeField(blank=True, null=True)),
-                ('value_bool', models.NullBooleanField()),
+                ('value_bool', models.BooleanField(blank=True, null=True)),
                 ('generic_value_id', models.IntegerField(blank=True, null=True)),
                 ('created', models.DateTimeField(default=django.utils.timezone.now, verbose_name='created')),
                 ('modified', models.DateTimeField(auto_now=True, verbose_name='modified')),

--- a/eav/models.py
+++ b/eav/models.py
@@ -356,7 +356,7 @@ class Value(models.Model):
     value_float = models.FloatField(blank=True, null=True)
     value_int = models.IntegerField(blank=True, null=True)
     value_date = models.DateTimeField(blank=True, null=True)
-    value_bool = models.NullBooleanField(blank=True, null=True)
+    value_bool = models.BooleanField(blank=True, null=True)
     value_enum = models.ForeignKey(EnumValue, blank=True, null=True,
                                    related_name='eav_values')
 


### PR DESCRIPTION
Updated `NullBooleanField()` to `BooleanField(null=True)` for compatibility with Django 4.0 